### PR TITLE
Get email forwarding working.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,22 @@
 #	The password to be used for the admin user on first login. This is ignored
 #	after the Grafana database has been built.
 #
+# TTN_DASHBOARD_GRAFANA_PROJECT_NAME
+#	The project name to be used for the emails from the administrator.
+#
+# TTN_DASHBOARD_GRAFANA_LOG_MODE
+#	Set the grafana log mode.
+#
+# TTN_DASHBOARD_GRAFANA_LOG_LEVEL
+#	Set the grafana log level (e.g. debug)
+#
+# TTN_DASHBOARD_GRAFANA_SMTP_ENABLED
+#	Set to true to enable SMTP.
+#
+# TTN_DASHBOARD_GRAFANA_SMTP_HOST_FQDN
+#	The FQDN of the smtp host to be used for sending mail.
+#	Defaults to localhost.
+#
 # TTN_DASHBOARD_INFLUXDB_ADMIN_PASSWORD
 #	The password to be used for the admin user by influxdb. Again, this is 
 #	ignored after the influxdb database has been built.
@@ -121,7 +137,14 @@ services:
       - "${TTN_DASHBOARD_DATA}grafana:/var/lib/grafana"
     environment:
       GF_SECURITY_ADMIN_PASSWORD: "${TTN_DASHBOARD_GRAFANA_ADMIN_PASSWORD:-!notset}"
-      GF_SERVER_ROOT_URL: '%(protocol)s://%(domain)s:%(http_port)s/grafana/'
+      GF_SERVER_DOMAIN: ${TTN_DASHBOARD_APACHE_FQDN}
+      GF_SERVER_ROOT_URL: 'https://%(domain)s/grafana/'
+      GF_SMTP_ENABLED: ${TTN_DASHBOARD_GRAFANA_SMTP_ENABLED:-false}
+      GF_SMTP_HOST: ${TTN_DASHBOARD_GRAFANA_SMTP_HOST_FQDN:-localhost}:25
+      GF_SMTP_FROM_ADDRESS: "grafana@${TTN_DASHBOARD_GRAFANA_SMTP_HOST_FQDN:-localhost}"
+      GF_SMTP_FROM_NAME: "${TTN_DASHBOARD_GRAFANA_PROJECT_NAME:-Default} grafana admin"
+      GF_LOG_MODE: ${TTN_DASHBOARD_GRAFANA_LOG_MODE:-console,file}
+      GF_LOG_LEVEL: ${TTN_DASHBOARD_GRAFANA_LOG_LEVEL:-info}
 
     # grafana opens ports on influxdb, so it needs to be able to talk to it.
     links:


### PR DESCRIPTION
This addresses #6, on the assumption that the container host system has a mail forwarder listening on port 25 and willing to forward mail for the docker network.
 
* enable smtp
* forward mail to the enclosing system's SMTP server
* correct errors in the `GF_SERVER_ROOT_URL` and `GF_SERVER_DOMAIN` setting, which messed up links in sign-up messages (and probably in password-recovery emails as well)
* add ability to override logging settings from `TTN_DASHBOARD_GRAFANA_LOG_MODE` and `TTN_DASHBOARD_GRAFANA__LOG_LEVEL` variables

For this to work, I changed my host's `/etc/postfix/main.cf` to add the following:
```
inet_interfaces = $myhostname, localhost
mynetworks=127.0.0.0/8, 172.18.0.0/24
```
Where `172.18.0.0` is the docker private network used for the docker-compose app on my machine.