### PR TITLE
Add some HTTP security-related headers

### DIFF
--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -18,7 +18,7 @@ RUN /usr/sbin/a2enmod proxy && \
     /usr/sbin/a2enmod proxy_http && \
     echo "ServerName localhost" > /etc/apache2/conf-available/fqdn.conf && \
     /usr/sbin/a2enconf fqdn.conf && \
-    /usr/sbin/a2enmod authz_user authz_groupfile proxy_wstunnel
+    /usr/sbin/a2enmod authz_user authz_groupfile proxy_wstunnel headers
 
 # RUN mkdir -p /root
 COPY setup.sh proxy-*.conf /root/

--- a/apache/proxy-grafana.conf
+++ b/apache/proxy-grafana.conf
@@ -1,7 +1,16 @@
 	Redirect 301 / https://@{FQDN}/grafana/
 	Redirect 301 /index.html https://@{FQDN}/grafana/
-        Redirect 301 /grafana https://@{FQDN}/grafana/
-        <Location "/grafana/" >
-                ProxyPass http://grafana:3000/
-                ProxyPassReverse http://grafana:3000/
-        </Location>
+	Redirect 301 /grafana https://@{FQDN}/grafana/
+	<Location "/grafana/" >
+		  Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains"
+		  Header always set X-Frame-Options "SAMEORIGIN"
+		  Header always set X-Xss-Protection "1; mode=block"
+		  Header always set X-Content-Type-Options "nosniff"
+		  Header always set Content-Security-Policy "default-src 'self' https:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:"
+		  Header always set Referrer-Policy: "same-origin"
+		  Header always set Feature-Policy: "accelerometer 'none'; camera 'none'; geolocation 'none'; gyroscope 'none'; magnetometer 'none'; microphone 'none'; payment 'none'; usb 'none'"
+		  Header edit Set-Cookie ^(.*)$ $1;Secure
+		  ProxyPass http://grafana:3000/
+		  ProxyPassReverse http://grafana:3000/
+		  ProxyPassReverseCookiePath / /grafana/
+	</Location>

--- a/apache/proxy-influxdb.conf
+++ b/apache/proxy-influxdb.conf
@@ -1,5 +1,12 @@
 	Redirect 301 /influxdb:8086/ https://@{FQDN}/influxdb:8086/
 	<Location "/influxdb:8086/">
+		Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains"
+		Header always set X-Frame-Options "SAMEORIGIN"
+		Header always set X-Xss-Protection "1; mode=block"
+		Header always set X-Content-Type-Options "nosniff"
+		Header always set Content-Security-Policy "default-src 'self'"
+		Header always set Referrer-Policy: "same-origin"
+		Header always set Feature-Policy: "accelerometer 'none'; camera 'none'; geolocation 'none'; gyroscope 'none'; magnetometer 'none'; microphone 'none'; payment 'none'; usb 'none'"
 		AuthType Basic
 		AuthName "InfluxDB queries"
 		AuthUserFile /etc/apache2/authdata/.htpasswd

--- a/apache/proxy-nodered.conf
+++ b/apache/proxy-nodered.conf
@@ -1,15 +1,22 @@
-        ProxyPass /node-red/comms/ ws://node-red:1880/comms/
-        ProxyPassReverse /node-red/comms/ ws://node-red:1880/comms/
-        ProxyPass /node-red/comms ws://node-red:1880/comms
-        ProxyPassReverse /node-red/comms ws://node-red:1880/comms
-        ProxyPass /node-red/ http://node-red:1880/
-        ProxyPassReverse /node-red/ http://node-red:1880/
+	ProxyPass /node-red/comms/ ws://node-red:1880/comms/
+	ProxyPassReverse /node-red/comms/ ws://node-red:1880/comms/
+	ProxyPass /node-red/comms ws://node-red:1880/comms
+	ProxyPassReverse /node-red/comms ws://node-red:1880/comms
+	ProxyPass /node-red/ http://node-red:1880/
+	ProxyPassReverse /node-red/ http://node-red:1880/
 
 	Redirect 301 /node-red https://@{FQDN}/node-red/
 	<Location "/node-red/">
-                AuthType Basic
-                AuthName "Node-RED"
-                AuthUserFile /etc/apache2/authdata/.htpasswd
-                AuthGroupFile /etc/apache2/authdata/.htgroup
-                Require group node-red
+		  Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains"
+		  Header always set X-Frame-Options "SAMEORIGIN"
+		  Header always set X-Xss-Protection "1; mode=block"
+		  Header always set X-Content-Type-Options "nosniff"
+		  Header always set Content-Security-Policy "default-src 'self' https:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:"
+		  Header always set Referrer-Policy: "same-origin"
+		  Header always set Feature-Policy: "accelerometer 'none'; camera 'none'; geolocation 'none'; gyroscope 'none'; magnetometer 'none'; microphone 'none'; payment 'none'; usb 'none'"
+		  AuthType Basic
+		  AuthName "Node-RED"
+		  AuthUserFile /etc/apache2/authdata/.htpasswd
+		  AuthGroupFile /etc/apache2/authdata/.htgroup
+		  Require group node-red
 	</Location>


### PR DESCRIPTION
Hi,
This PR adds some HTTP headers that will raise the grade from F to B (Grafana), F to A (Node-Red) on https://securityheaders.com.
Also, https://www.ssllabs.com now gives an A+.
@terrillmoore There are still Referrer-Policy and Feature-Policy left to be defined, but those are kind of touchy. If you have any ideas, please let me know !
Regards,