### PR TITLE
Installing plugins for Grafana

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,11 +78,13 @@ Remember, if your server is running on a cloud platform like Microsoft Azure or 
    This sets the *initial* password for the Grafana `admin` login. You should change this via the Grafana UI after booting the server.
    6. `TTN_DASHBOARD_GRAFANA_SMTP_FROM_ADDRESS`
    This sets the Grafana originating mail address.
-   7. `TTN_DASHBOARD_INFLUXDB_INITIAL_DATABASE_NAME=demo`
+   7. `TTN_DASHBOARD_GRAFANA_INSTALL_PLUGINS`
+   This sets a list of Grafana plugins to install.
+   8. `TTN_DASHBOARD_INFLUXDB_INITIAL_DATABASE_NAME=demo`
    Change "demo" to the desired name of the initial database that will be created in InfluxDB. 
-   8. `TTN_DASHBOARD_MAIL_HOST_NAME=myhost.example.com`
+   9. `TTN_DASHBOARD_MAIL_HOST_NAME=myhost.example.com`
    This sets the name of your mail server. Used by Postfix.
-   9. `TTN_DASHBOARD_MAIL_DOMAIN=example.com`
+   10. `TTN_DASHBOARD_MAIL_DOMAIN=example.com`
    This sets the domain name of your mail server. Used by Postfix.
    
 Your `.env` file should look like this:
@@ -94,6 +96,7 @@ Your `.env` file should look like this:
     TTN_DASHBOARD_CERTBOT_EMAIL=someone@example.com
     TTN_DASHBOARD_GRAFANA_ADMIN_PASSWORD=SomethingVerySecretIndeed
     TTN_DASHBOARD_GRAFANA_SMTP_FROM_ADDRESS=grafana@example.com
+    TTN_DASHBOARD_GRAFANA_INSTALL_PLUGINS=grafana-worldmap-panel,grafana-clock-panel,grafana-piechart-panel
     TTN_DASHBOARD_INFLUXDB_INITIAL_DATABASE_NAME=demo
     TTN_DASHBOARD_MAIL_HOST_NAME=myhost.example.com
     TTN_DASHBOARD_MAIL_DOMAIN=example.com

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,9 @@
 #	The FQDN of the smtp host to be used for sending mail.
 #	Defaults to localhost.
 #
+# TTN_DASHBOARD_GRAFANA_INSTALL_PLUGINS
+#	A list of grafana plugins to install.
+#
 # TTN_DASHBOARD_INFLUXDB_ADMIN_PASSWORD
 #	The password to be used for the admin user by influxdb. Again, this is 
 #	ignored after the influxdb database has been built.
@@ -171,15 +174,16 @@ services:
       - "${TTN_DASHBOARD_DATA}grafana:/var/lib/grafana"
     environment:
       GF_SECURITY_ADMIN_PASSWORD: "${TTN_DASHBOARD_GRAFANA_ADMIN_PASSWORD:-!notset}"
-      GF_SERVER_DOMAIN: ${TTN_DASHBOARD_APACHE_FQDN}
-      GF_SERVER_ROOT_URL: 'https://%(domain)s/grafana/'
-      GF_SMTP_ENABLED: ${TTN_DASHBOARD_GRAFANA_SMTP_ENABLED:-false}
-      GF_SMTP_SKIP_VERIFY: ${TTN_DASHBOARD_GRAFANA_SMTP_SKIP_VERIFY:-false}
-      GF_SMTP_HOST: ${TTN_DASHBOARD_MAIL_HOST_NAME:-localhost}:25
-      GF_SMTP_FROM_ADDRESS: ${TTN_DASHBOARD_GRAFANA_SMTP_FROM_ADDRESS:-grafana@localhost}
+      GF_SERVER_DOMAIN: "${TTN_DASHBOARD_APACHE_FQDN}"
+      GF_SERVER_ROOT_URL: "https://%(domain)s/grafana/"
+      GF_SMTP_ENABLED: "${TTN_DASHBOARD_GRAFANA_SMTP_ENABLED:-false}"
+      GF_SMTP_SKIP_VERIFY: "${TTN_DASHBOARD_GRAFANA_SMTP_SKIP_VERIFY:-false}"
+      GF_SMTP_HOST: "${TTN_DASHBOARD_MAIL_HOST_NAME:-localhost}:25"
+      GF_SMTP_FROM_ADDRESS: "${TTN_DASHBOARD_GRAFANA_SMTP_FROM_ADDRESS:-grafana@localhost}"
       GF_SMTP_FROM_NAME: "${TTN_DASHBOARD_GRAFANA_PROJECT_NAME:-Default} grafana admin"
-      GF_LOG_MODE: ${TTN_DASHBOARD_GRAFANA_LOG_MODE:-console,file}
-      GF_LOG_LEVEL: ${TTN_DASHBOARD_GRAFANA_LOG_LEVEL:-info}
+      GF_LOG_MODE: "${TTN_DASHBOARD_GRAFANA_LOG_MODE:-console,file}"
+      GF_LOG_LEVEL: "${TTN_DASHBOARD_GRAFANA_LOG_LEVEL:-info}"
+      GF_INSTALL_PLUGINS: "${TTN_DASHBOARD_GRAFANA_INSTALL_PLUGINS:-}"
     # grafana opens ports on influxdb and postfix, so it needs to be able to talk to it.
     links:
       - influxdb


### PR DESCRIPTION
This adds a new configuration variable TTN_DASHBOARD_GRAFANA_INSTALL_PLUGINS to install [extra grafana plugins](docs.grafana.org/installation/docker/) to the container.

Also makes usage of "" consistent with the rest of the docker-compose.yml file.