### PR TITLE
Use postfix:25 as GF_SMTP_HOST

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -180,7 +180,7 @@ services:
       GF_SERVER_ROOT_URL: "https://%(domain)s/grafana/"
       GF_SMTP_ENABLED: "${TTN_DASHBOARD_GRAFANA_SMTP_ENABLED:-false}"
       GF_SMTP_SKIP_VERIFY: "${TTN_DASHBOARD_GRAFANA_SMTP_SKIP_VERIFY:-false}"
-      GF_SMTP_HOST: "${TTN_DASHBOARD_MAIL_HOST_NAME:-postfix}:25"
+      GF_SMTP_HOST: "postfix:25"
       GF_SMTP_FROM_ADDRESS: "${TTN_DASHBOARD_GRAFANA_SMTP_FROM_ADDRESS:-grafana@localhost}"
       GF_SMTP_FROM_NAME: "${TTN_DASHBOARD_GRAFANA_PROJECT_NAME:-Default} grafana admin"
       GF_LOG_MODE: "${TTN_DASHBOARD_GRAFANA_LOG_MODE:-console,file}"


### PR DESCRIPTION
TTN_DASHBOARD_MAIL_HOST_NAME is needed for correct Postfix configuration, link directly to postfix container.