### PR TITLE
Content-Security-Policy: add img-src *.global.ssl.fastly.net

### DIFF
--- a/apache/proxy-grafana.conf
+++ b/apache/proxy-grafana.conf
@@ -6,7 +6,7 @@
 		  Header always set X-Frame-Options "SAMEORIGIN"
 		  Header always set X-Xss-Protection "1; mode=block"
 		  Header always set X-Content-Type-Options "nosniff"
-		  Header always set Content-Security-Policy "default-src 'self' https:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:"
+		  Header always set Content-Security-Policy "default-src 'self' https:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: *.global.ssl.fastly.net"
 		  Header always set Referrer-Policy: "same-origin"
 		  Header always set Feature-Policy: "accelerometer 'none'; camera 'none'; geolocation 'none'; gyroscope 'none'; magnetometer 'none'; microphone 'none'; payment 'none'; usb 'none'"
 		  Header edit Set-Cookie ^(.*)$ $1;Secure


### PR DESCRIPTION
This is needed if one uses Grafana's WorldMap plugin (or else CSP will prevent the browser from loading map tiles):

`Content Security Policy: The page’s settings blocked the loading of a resource at https://cartodb-basemaps-a.global.ssl.fastly.net/dark_all/1/0/0.png (“img-src”).`