### PR TITLE
Add TTN_DASHBOARD_TIMEZONE

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -205,6 +205,9 @@ The following instructions are essentially indenpendent of the cloud provider an
    10. `TTN_DASHBOARD_MAIL_DOMAIN=example.com`
    This sets the domain name of your mail server. Used by Postfix.
 
+   11. `TTN_DASHBOARD_TIMEZONE=Europe/Paris`
+   If not defined, the default timezone will be GMT.
+
 Your `.env` file should look like this:
 
 ```sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -110,6 +110,9 @@
 # TTN_DASHBOARD_PORT_HTTPS
 #	The port to listen to for HTTPS. Primarily for test purposes. Defaults to
 #	443.
+#
+# TTN_DASHBOARD_TIMEZONE
+#	The timezone to use. Defaults to GMT.
 #---
 
 # Also see apache/setup.sh, which uses some additional test variables when
@@ -155,6 +158,8 @@ services:
     links:
       - influxdb
       - postfix
+    environment:
+      - TZ: "${TTN_DASHBOARD_TIMEZONE:-GMT}"
 
   influxdb:
     restart: unless-stopped


### PR DESCRIPTION
Node-Red needs TZ to be set in order to operate correctly, see e.g.:
* https://discourse.nodered.org/t/node-red-triggers-using-utc-instead-of-local-timezone/7324/5
* https://github.com/node-red/node-red-docker/issues/48

Setting TZ as environment variable works ok for me on recent versions.

Maybe it would be wise to also add this to Grafana ?