### PR TITLE
Fix #40: add enable/disable user grafana sign-up

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -264,6 +264,9 @@ TTN_DASHBOARD_GRAFANA_SMTP_ENABLED=true
 TTN_DASHBOARD_GRAFANA_SMTP_FROM_ADDRESS=grafana-admin@dashboard.example.com
 # The "from" address for Grafana emails.
 #
+# TTN_DASHBOARD_GRAFANA_USERS_ALLOW_SIGN_UP=
+#	Set to true to allow users to sign-up to get access to the dashboard.
+#
 TTN_DASHBOARD_INFLUXDB_ADMIN_PASSWORD=jadb4a4WH5za7wvp
 #       The password to be used for the admin user by influxdb. Again, this is
 #       ignored after the influxdb database has been built.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,6 +86,9 @@
 # TTN_DASHBOARD_GRAFANA_SMTP_FROM_ADDRESS
 # The "from" address for Grafana emails.
 #
+# TTN_DASHBOARD_GRAFANA_USERS_ALLOW_SIGN_UP
+#	Set to true to allow users to sign up.
+#
 # TTN_DASHBOARD_INFLUXDB_ADMIN_PASSWORD
 #	The password to be used for the admin user by influxdb. Again, this is
 #	ignored after the influxdb database has been built.
@@ -218,6 +221,7 @@ services:
       GF_LOG_MODE: "${TTN_DASHBOARD_GRAFANA_LOG_MODE:-console,file}"
       GF_LOG_LEVEL: "${TTN_DASHBOARD_GRAFANA_LOG_LEVEL:-info}"
       GF_INSTALL_PLUGINS: "${TTN_DASHBOARD_GRAFANA_INSTALL_PLUGINS:-}"
+      GF_USERS_ALLOW_SIGN_UP: "${TTN_DASHBOARD_GRAFANA_USERS_ALLOW_SIGN_UP:-false}"
     # grafana opens ports on influxdb and postfix, so it needs to be able to talk to it.
     links:
       - influxdb


### PR DESCRIPTION
Allow `.env` to control whether grafana allows users self-service sign up.