### PR TITLE
Fix #48: spurious dash in Node-RED environment block

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -162,7 +162,7 @@ services:
       - influxdb
       - postfix
     environment:
-      - TZ: "${TTN_DASHBOARD_TIMEZONE:-GMT}"
+      TZ: "${TTN_DASHBOARD_TIMEZONE:-GMT}"
 
   influxdb:
     restart: unless-stopped


### PR DESCRIPTION
This was wrong, but apparently worked anyway. Newer docker-compose is more strict.