### PR TITLE
Node-Red 1.0

### DIFF
--- a/node-red/Dockerfile
+++ b/node-red/Dockerfile
@@ -3,7 +3,7 @@
 #
 
 # build the node red image using the offical node red distribution
-FROM nodered/node-red-docker:latest
+FROM nodered/node-red:latest
 
 # To avoid SSL certification issue
 ENV NODE_TLS_REJECT_UNAUTHORIZED=0


### PR DESCRIPTION
[nodered/node-red-docker](https://hub.docker.com/r/nodered/node-red-docker) has been deprecated in favor of [nodered/node-red](https://hub.docker.com/r/nodered/node-red) since the release of Node-Red 1.0.

This PR switches to the latest image (currently 1.0.2).